### PR TITLE
Fix multi comment escape (GH-7)

### DIFF
--- a/Scripter.Plugin/src/Lib/Parsing/Tokenizer.cs
+++ b/Scripter.Plugin/src/Lib/Parsing/Tokenizer.cs
@@ -96,7 +96,7 @@ namespace ScripterLang
                         if (next == '*')
                         {
                             MoveNext();
-                            while (MoveNext() && Current != '*' && Peek() != '/')
+                            while (MoveNext() && (Current != '*' || Peek() != '/'))
                             {
                             }
 

--- a/Scripter.Tests/Parsing/TokenizerTests.cs
+++ b/Scripter.Tests/Parsing/TokenizerTests.cs
@@ -60,6 +60,15 @@ public class TokenizerTests
             /*
             x = x + 1;
             */
+            /**
+              * x = x + 1;
+              */
+            /**/
+            /*comment*/
+            /* comment */
+            /*/*/
+            /***/
+
             return x;
             """);
 


### PR DESCRIPTION
A fix for #7

# Current version
![image](https://github.com/acidbubbles/vam-scripter/assets/165130600/586afc72-66a8-4162-81df-7f9c274a3232)

# New changes
![image](https://github.com/acidbubbles/vam-scripter/assets/165130600/04d82804-8b22-4d4e-9c0a-11e4a09e07a7)

